### PR TITLE
Initialize backend and frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python virtual environments
+venv/
+ENV/
+*.egg-info/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+
+# Editor directories and files
+*.swp
+.idea/
+.vscode/
+
+# Node dependencies for frontend
+node_modules/
+
+.DS_Store

--- a/backend/ai.py
+++ b/backend/ai.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/")
+async def ai_root():
+    return {"message": "AI placeholder"}

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/")
+async def read_db_root():
+    return {"message": "CRUD placeholder"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+from .crud import router as crud_router
+from .ai import router as ai_router
+
+app = FastAPI()
+
+app.include_router(crud_router, prefix="/db", tags=["database"])
+app.include_router(ai_router, prefix="/ai", tags=["ai"])
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,6 @@
+# Placeholder for database models
+
+from pydantic import BaseModel
+
+class Item(BaseModel):
+    name: str

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,6 @@
+# Placeholder for Pydantic schemas
+
+from pydantic import BaseModel
+
+class ItemCreate(BaseModel):
+    name: str

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,4 @@
+# Frontend
+
+This directory will contain the Quasar/Vue.js application for WriteDarker.
+Further setup with Quasar CLI will be added in the future.


### PR DESCRIPTION
## Summary
- set up backend and frontend folders
- add FastAPI placeholders (`main.py`, `crud.py`, `ai.py`, `models.py`, `schemas.py`)
- add frontend README stub
- create `.gitignore` for venvs and build artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b7039bd883229c3b13a82f8fc0d5