### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,35 @@
 # WriteDarker
-Projekt um Paper mit LLM zu schreiben
 
-## Projektidee
+WriteDarker is an early-stage experiment to build a collaborative writing environment.
+Currently this repository only contains planning notes and a minimal project skeleton.
 
-Die Idee ist, eine Web App zu programmieren, mit der man gemeinsam an einem wissenschaftlichen Paper schreiben kann. Dafür werden folgende Komponenten benötigt:
+## Vision
 
-1. **Web UI**  
-   Die Benutzeroberfläche soll als Webanwendung umgesetzt werden, idealerweise mit [Quasar Framework](https://quasar.dev/) (Vue.js-basiert). Sie ermöglicht das Schreiben, Bearbeiten und Verwalten von Paper-Inhalten.
+The goal is to create a web application that feels like a lightweight Google Docs alternative. Users will be able to:
 
-2. **Datenbank**  
-   Eine relationale Datenbank, vorzugsweise [PostgreSQL](https://www.postgresql.org/), verwaltet Literaturquellen, Projekte und die eigenen Texte. Sie dient als zentrales Speichersystem für alle relevanten Daten.  Zunächst aber Implementation von SQLlite.
+- write papers in clearly separated sections (title, abstract, introduction, etc.)
+- request iterative AI suggestions for each section to refine the text
+- manage projects and authenticate across sessions
+- store references in a literature database
 
-3. **Backend**  
-   Das Backend wird idealerweise in Python entwickelt. Es übernimmt die Kommunikation zwischen der Web UI, der Datenbank und der OpenAI ChatGPT API. So können Texte generiert, gespeichert und abgerufen werden.
+## Repository Layout
 
-## Kernfunktionen
+The directories present here are mostly placeholders:
 
-- **Literaturdatenbank:**  
-  Verwaltung und Pflege von Literaturquellen, die für das Paper genutzt werden können.
+```
+backend/   # FastAPI skeleton (no real API yet)
+frontend/  # Quasar/Vue.js placeholder
+```
 
-- **Paper schreiben im Markdown-Format:**  
-  Erstellung und Bearbeitung wissenschaftlicher Paper im Markdown-Format, inklusive der Möglichkeit, Literaturquellen direkt einzupflegen.
+Additional modules such as CRUD operations and AI endpoints are stubs only. The detailed
+structure described below is still planned and not implemented.
 
-- **Struktur eines wissenschaftlichen Papers:**  
-  Unterstützung der typischen Struktur mit folgenden Abschnitten:
-  - Titel
-  - Abstract
-  - Einleitung
-  - Methodenteil
-  - Ergebnisse
-  - Diskussion
-  - Zusammenfassung
+## Running the Backend (planned)
 
+Once the backend is implemented you will be able to:
 
+1. Create a Python environment with `python -m venv venv` and activate it.
+2. Install dependencies, e.g. `pip install fastapi uvicorn`.
+3. Start the application with `uvicorn backend.main:app --reload`.
 
-- **KI-Funktionen für einzelne Abschnitte:**  
-  Für jeden Abschnitt stehen KI-gestützte Funktionen wie AutoText, Chat und weitere Schreibunterstützungen zur Verfügung.
-
-<!-- Weitere Funktionen können hier ergänzt werden -->
-WriteDarker/
-│
-├── backend/
-│   ├── app/
-│   │   ├── __init__.py
-│   │   ├── main.py         # FastAPI-Anwendung
-│   │   ├── crud.py         # CRUD-Operationen für DB
-│   │   ├── models.py       # SQLAlchemy-Modelle
-│   │   ├── schemas.py      # Pydantic-Schemas
-│   │   └── ai.py           # Endpunkte für KI (z.B. mcP-Protokoll)
-│   ├── database.db         # SQLite-Datenbank (wird automatisch erstellt)
-│   └── requirements.txt    # Python-Abhängigkeiten
-│
-├── frontend/
-│   └── ...                 # Quasar/Vue.js-Projekt
-│
-├── README.md
-└── .gitignore
-
-
-## Backend
-
-from fastapi import FastAPI
-from . import crud, ai, models
-from .database import engine
-
-models.Base.metadata.create_all(bind=engine)
-
-app = FastAPI()
-
-app.include_router(crud.router, prefix="/db", tags=["database"])
-app.include_router(ai.router, prefix="/ai", tags=["ai"])
-
+These instructions are provisional until a full `requirements.txt` is added.


### PR DESCRIPTION
## Summary
- overhaul README
- clarify that the repo only contains planning documents and placeholders
- outline planned features for the editor, AI review, auth, projects and literature DB
- provide placeholder backend run instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b7edcf988322ab05a6eadd17a2a7