### PR TITLE
Add LICENSE and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to WriteDarker
+
+Thank you for your interest in contributing! Follow these guidelines to get started.
+
+## Branching Model
+
+- The `main` branch contains stable code. Create new branches from `main` for each feature or bugfix.
+- Use descriptive branch names, e.g. `feature/ai-endpoint` or `bugfix/login-error`.
+- Submit a pull request back to `main` when your work is ready.
+
+## Coding Standards
+
+- Keep the codebase Pythonic and consistent with [PEP8](https://peps.python.org/pep-0008/).
+- Include type hints where practical.
+- Add docstrings to public functions and classes.
+- Before committing, run tests and linters if available.
+
+## Issue Tracking
+
+- Report bugs and request features using GitHub Issues.
+- When sending a pull request, reference the relevant issue number if one exists.
+
+We appreciate your contributions!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 WriteDarker contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Once the backend is implemented you will be able to:
 3. Start the application with `uvicorn backend.main:app --reload`.
 
 These instructions are provisional until a full `requirements.txt` is added.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up branches, follow coding standards, and track issues.
+
+## License
+
+This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add MIT License
- create CONTRIBUTING guide
- reference new docs from README

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b8b24c5883228b606cf9c8341ffb