### PR TITLE
Add PubMed fetch and tests

### DIFF
--- a/backend/services/references.py
+++ b/backend/services/references.py
@@ -1,20 +1,57 @@
 """Utility functions for fetching references from PubMed."""
 
+from xml.etree import ElementTree
+
 import httpx
 
 
-def fetch_reference(query: str) -> dict:
-    """Return basic metadata for the first PubMed result for `query`."""
-    url = "https://pubmed.ncbi.nlm.nih.gov/?term=" + query
-    try:
-        resp = httpx.get(url, timeout=10)
-        resp.raise_for_status()
-        # Dummy parsing due to simplicity
-        title = query
-    except Exception:
-        title = query
+def _parse_pubmed_xml(xml: str) -> dict:
+    """Parse minimal fields from an efetch PubMed XML response."""
+    tree = ElementTree.fromstring(xml)
+
+    article = tree.find(".//PubmedArticle")
+    if article is None:
+        return {}
+
+    title = article.findtext(".//ArticleTitle", default="")
+    year = (
+        article.findtext(".//PubDate/Year")
+        or article.findtext(".//PubDate/MedlineDate", default="")[:4]
+    )
+    journal = article.findtext(".//ISOAbbreviation", default="")
+
+    authors = []
+    for author in article.findall(".//Author"):
+        last = author.findtext("LastName")
+        initials = author.findtext("Initials")
+        if last and initials:
+            authors.append(f"{last} {initials}")
+    authors_str = ", ".join(authors)
+
     return {
         "title": title,
+        "authors": authors_str,
+        "journal": journal,
+        "year": year,
+    }
+
+
+def fetch_reference(query: str) -> dict:
+    """Return basic metadata for a PubMed ID or search term."""
+    if query.isdigit():
+        url = (
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed"
+            f"&id={query}&retmode=xml"
+        )
+        resp = httpx.get(url, timeout=10)
+        resp.raise_for_status()
+        data = _parse_pubmed_xml(resp.text)
+        if data:
+            return data
+
+    # fallback to original behaviour for arbitrary queries
+    return {
+        "title": query,
         "authors": "",
         "journal": "",
         "year": "",

--- a/tests/test_pubmed_api.py
+++ b/tests/test_pubmed_api.py
@@ -1,0 +1,93 @@
+import sys, os
+import uuid
+from unittest.mock import patch
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+SAMPLE_XML = """<?xml version='1.0' encoding='UTF-8'?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <Article>
+        <Journal>
+          <JournalIssue>
+            <PubDate>
+              <Year>2024</Year>
+            </PubDate>
+          </JournalIssue>
+          <ISOAbbreviation>J Neurol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Persistent cognitive slowing in post-COVID patients: longitudinal study over 6 months.</ArticleTitle>
+        <AuthorList>
+          <Author><LastName>Martin</LastName><Initials>EM</Initials></Author>
+          <Author><LastName>Srowig</LastName><Initials>A</Initials></Author>
+          <Author><LastName>Utech</LastName><Initials>I</Initials></Author>
+          <Author><LastName>Schrenk</LastName><Initials>S</Initials></Author>
+          <Author><LastName>Kattlun</LastName><Initials>F</Initials></Author>
+          <Author><LastName>Radscheidt</LastName><Initials>M</Initials></Author>
+          <Author><LastName>Brodoehl</LastName><Initials>S</Initials></Author>
+          <Author><LastName>Bublak</LastName><Initials>P</Initials></Author>
+          <Author><LastName>Schwab</LastName><Initials>M</Initials></Author>
+          <Author><LastName>Geis</LastName><Initials>C</Initials></Author>
+          <Author><LastName>Besteher</LastName><Initials>B</Initials></Author>
+          <Author><LastName>Reuken</LastName><Initials>PA</Initials></Author>
+          <Author><LastName>Stallmach</LastName><Initials>A</Initials></Author>
+          <Author><LastName>Finke</LastName><Initials>K</Initials></Author>
+        </AuthorList>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+
+class FakeResponse:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+
+def mock_get(url, timeout=10):
+    return FakeResponse(SAMPLE_XML)
+
+
+def get_token():
+    username = f"ref_{uuid.uuid4().hex[:6]}"
+    client.post("/auth/register", json={"username": username, "password": "secret"})
+    resp = client.post("/auth/login", json={"username": username, "password": "secret"})
+    return resp.json()["access_token"]
+
+
+def test_fetch_pubmed_reference_and_store():
+    token = get_token()
+    proj_resp = client.post(
+        "/projects/",
+        params={"token": token},
+        json={"label": "Ref", "description": "test"},
+    )
+    assert proj_resp.status_code == 200
+    proj_id = proj_resp.json()["id"]
+
+    with patch("backend.services.references.httpx.get", side_effect=mock_get):
+        resp = client.post(
+            "/references/",
+            params={"token": token},
+            data={"project_id": proj_id, "query": "37936010"},
+        )
+
+    assert resp.status_code == 200
+    ref = resp.json()
+    assert ref["title"] == "Persistent cognitive slowing in post-COVID patients: longitudinal study over 6 months."
+    assert ref["authors"].startswith("Martin EM")
+    assert ref["authors"].endswith("Finke K")
+    assert ref["journal"] == "J Neurol"
+    assert ref["year"] == "2024"
+
+    get_resp = client.get(f"/references/{ref['id']}", params={"token": token})
+    assert get_resp.status_code == 200
+    assert get_resp.json() == ref


### PR DESCRIPTION
## Summary
- parse PubMed XML responses
- fetch reference data by PMID
- cover PubMed reference API with a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887df3723a88322b45cda1414d30bfa