### PR TITLE
Improve development start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ implemented together with example tests.
    uvicorn backend.main:app --reload
    ```
 
+## Development Setup
+
+To install all JavaScript and Python dependencies and run both the
+backend and frontend together:
+
+1. Install root npm packages and create the virtual environment:
+
+   ```bash
+   npm install
+   npm run setup
+   ```
+
+2. Start the development servers (backend API and React app):
+
+   ```bash
+   npm run start
+   ```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up branches, follow coding standards, and track issues.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "setup": "bash -c 'if [ ! -d venv ]; then python -m venv venv && ./venv/bin/pip install -r requirements.txt; fi && cd frontend && npm install'",
-    "start:backend": "uvicorn backend.main:app --reload",
+    "start:backend": "./venv/bin/uvicorn backend.main:app --reload",
     "start:frontend": "cd frontend && npm run dev",
     "start": "concurrently -k \"npm run start:backend\" \"npm run start:frontend\""
   },


### PR DESCRIPTION
## Summary
- make backend start script use venv's uvicorn
- document development setup with npm scripts

## Testing
- `npm run start` *(manual: started backend and frontend)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6887e6b67008832284e2a76dc0bd4091