### PR TITLE
Add dotenv configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+SECRET_KEY=supersecretkey
+DB_PATH=./AppData/writedarker.db
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ implemented together with example tests.
    uvicorn backend.main:app --reload
    ```
 
+## Environment Variables
+
+Configuration values can be supplied via environment variables or a `.env` file
+at the repository root. Important variables include:
+
+```bash
+SECRET_KEY=supersecretkey
+DB_PATH=./AppData/writedarker.db
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+```
+
+`SECRET_KEY` is used to sign authentication tokens, `DB_PATH` specifies the
+SQLite database file, and `ACCESS_TOKEN_EXPIRE_MINUTES` controls how long
+generated tokens remain valid.
+
 ## Development Setup
 
 To install all JavaScript and Python dependencies and run both the

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,14 +1,22 @@
 import os
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+
+load_dotenv()
 
 # Store application data inside the repository to avoid permission issues
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 APPDATA_PATH = os.path.join(ROOT_DIR, "AppData")
 DB_NAME = "writedarker.db"
-DB_PATH = os.path.join(APPDATA_PATH, DB_NAME)
 
-os.makedirs(APPDATA_PATH, exist_ok=True)
+env_db_path = os.getenv("DB_PATH")
+if env_db_path:
+    DB_PATH = os.path.expanduser(env_db_path)
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+else:
+    DB_PATH = os.path.join(APPDATA_PATH, DB_NAME)
+    os.makedirs(APPDATA_PATH, exist_ok=True)
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
 

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -5,10 +5,16 @@ from typing import Optional
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+import os
+from dotenv import load_dotenv
 
-SECRET_KEY = "supersecretkey"
+load_dotenv()
+
+SECRET_KEY = os.getenv("SECRET_KEY", "supersecretkey")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30)
+)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-jose[cryptography]
 PyPDF2
 httpx
 python-multipart
+python-dotenv


### PR DESCRIPTION
## Summary
- support `.env` configuration
- read secret key and token expiry from environment variables
- allow `DB_PATH` override via environment
- document configurable variables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886f3ec6848322a50e88d2529daf5e