### PR TITLE
Improve markdown sanitization

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.11.0",
+        "dompurify": "^3.2.6",
         "markdown-it": "^14.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1785,6 +1786,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3465,6 +3473,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "dompurify": "^3.2.6",
     "markdown-it": "^14.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/__tests__/DocumentEditor.test.tsx
+++ b/frontend/src/__tests__/DocumentEditor.test.tsx
@@ -1,0 +1,7 @@
+import { renderSanitizedMarkdown } from '../pages/DocumentEditor'
+
+test('sanitizes malicious html', () => {
+  const html = renderSanitizedMarkdown('<img src=x onerror="alert(1)"><script>alert(1)</script>')
+  expect(html).not.toMatch(/<script>/)
+  expect(html).not.toMatch(/<img/)
+})

--- a/frontend/src/pages/DocumentEditor.tsx
+++ b/frontend/src/pages/DocumentEditor.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 import api from '../api'
 import { useAuth } from '../AuthContext'
 
 const md = new MarkdownIt()
+
+export function renderSanitizedMarkdown(text: string) {
+  const html = md.render(text)
+  return DOMPurify.sanitize(html)
+}
 
 export default function DocumentEditor() {
   const { id, docId } = useParams()
@@ -24,7 +30,7 @@ export default function DocumentEditor() {
   return (
     <div className="flex h-screen">
       <textarea className="w-1/2 p-2 border" value={text} onChange={e => setText(e.target.value)} onBlur={save} />
-      <div className="w-1/2 p-2 prose prose-invert overflow-auto" dangerouslySetInnerHTML={{ __html: md.render(text) }} />
+      <div className="w-1/2 p-2 prose prose-invert overflow-auto" dangerouslySetInnerHTML={{ __html: renderSanitizedMarkdown(text) }} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `dompurify` to client dependencies
- sanitize rendered HTML in `DocumentEditor`
- add tests for HTML sanitization

## Testing
- `pytest -q`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888735579188322b52e00b3a9823b46