### PR TITLE
Load env vars from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,8 @@
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
+DB_DIR=./AppData
 SECRET_KEY=supersecretkey
-DB_PATH=./AppData/writedarker.db
+OPENAI_TOKEN=your-openai-token
+DOC_HISTORY_LIMIT=20
 ACCESS_TOKEN_EXPIRE_MINUTES=30
-
+ALLOWED_ORIGINS=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -51,16 +51,21 @@ Configuration values can be supplied via environment variables or a `.env` file
 at the repository root. Important variables include:
 
 ```bash
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
+DB_DIR=./AppData
 SECRET_KEY=supersecretkey
-DB_PATH=./AppData/writedarker.db
+OPENAI_TOKEN=your-openai-token
+DOC_HISTORY_LIMIT=20
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 ALLOWED_ORIGINS=http://localhost:5173
 ```
 
-`SECRET_KEY` is used to sign authentication tokens, `DB_PATH` specifies the
-SQLite database file, and `ACCESS_TOKEN_EXPIRE_MINUTES` controls how long
-generated tokens remain valid. `ALLOWED_ORIGINS` configures which origins can
-make cross-origin requests to the API (comma-separated list).
+`SECRET_KEY` is used to sign authentication tokens. The database file is stored
+inside the folder specified by `DB_DIR`. `ACCESS_TOKEN_EXPIRE_MINUTES` controls
+how long generated tokens remain valid. `ALLOWED_ORIGINS` configures which
+origins can make cross-origin requests to the API (comma-separated list). The
+`OPENAI_TOKEN` and `DOC_HISTORY_LIMIT` values are reserved for future features.
 
 ## Development Setup
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,22 +1,25 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-load_dotenv()
+# Load environment variables from the repository root
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 # Store application data inside the repository to avoid permission issues
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-APPDATA_PATH = os.path.join(ROOT_DIR, "AppData")
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPDATA_PATH = ROOT_DIR / "AppData"
 DB_NAME = "writedarker.db"
 
-env_db_path = os.getenv("DB_PATH")
-if env_db_path:
-    DB_PATH = os.path.expanduser(env_db_path)
-    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+# Determine the full database path
+db_dir = os.getenv("DB_DIR")
+if db_dir:
+    DB_PATH = Path(os.path.expanduser(db_dir)) / DB_NAME
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 else:
-    DB_PATH = os.path.join(APPDATA_PATH, DB_NAME)
-    os.makedirs(APPDATA_PATH, exist_ok=True)
+    DB_PATH = APPDATA_PATH / DB_NAME
+    APPDATA_PATH.mkdir(parents=True, exist_ok=True)
 
 SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,11 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import os
+from pathlib import Path
 from dotenv import load_dotenv
+
+# Load environment variables from the repository root
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 from .api.crud import router as crud_router
 from .api.ai import router as ai_router
@@ -11,8 +15,6 @@ from .api.projects import router as projects_router
 from .api.references import router as references_router
 from .api.settings import router as settings_router
 from .db import Base, engine
-
-load_dotenv()
 
 # Configure CORS
 origins_env = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173")

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -6,9 +6,11 @@ from typing import Optional
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+# Ensure environment variables are loaded when this module is imported
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 SECRET_KEY = os.getenv("SECRET_KEY", "supersecretkey")
 ALGORITHM = "HS256"


### PR DESCRIPTION
## Summary
- add example environment variable entries in `.env`
- load env vars from root in `backend.main`
- read env vars in authentication service
- compute DB path using `DB_DIR`
- document new environment variables

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888771c351c832289219fac70115743