### PR TITLE
Add MCP AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ how long generated tokens remain valid. `ALLOWED_ORIGINS` configures which
 origins can make cross-origin requests to the API (comma-separated list). The
 `OPENAI_TOKEN` and `DOC_HISTORY_LIMIT` values are reserved for future features.
 
+## AI MCP Endpoint
+
+A minimal AI endpoint exists at `POST /ai/mcp`. It accepts JSON with a `prompt`
+field and responds with a mocked Master Control Program style message. The
+response is generated locally for now. Future releases may use
+`OPENAI_TOKEN` to proxy prompts to an actual AI service.
+
 ## Development Setup
 
 To install all JavaScript and Python dependencies and run both the

--- a/backend/api/ai.py
+++ b/backend/api/ai.py
@@ -1,7 +1,33 @@
+"""Minimal AI-related endpoints."""
+
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 router = APIRouter()
+
+
+class Prompt(BaseModel):
+    """Request model containing the user's prompt."""
+
+    prompt: str
+
+
+class MCPReply(BaseModel):
+    """Mock response in the style of the Master Control Program."""
+
+    response: str
 
 @router.get("/")
 async def ai_root():
     return {"message": "AI placeholder"}
+
+
+@router.post("/mcp", response_model=MCPReply)
+async def mcp_reply(prompt: Prompt) -> MCPReply:
+    """Return a mocked MCP-style response for the given prompt."""
+
+    text = prompt.prompt.strip()
+    if not text:
+        text = "..."
+    # Placeholder logic - eventually this will call an external AI service
+    return MCPReply(response=f"MCP mock reply: {text}")

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,14 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_mcp_endpoint_returns_mock_response():
+    resp = client.post("/ai/mcp", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "response" in data
+    assert isinstance(data["response"], str)
+    assert "hello" in data["response"]


### PR DESCRIPTION
## Summary
- extend AI router with `POST /ai/mcp`
- return a mocked Master Control Program reply for now
- document the endpoint and mention future OPENAI_TOKEN use
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688879d8e0d88322810418b7ac6bb330