### PR TITLE
Implement document revision history

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -7,7 +7,9 @@ from sqlalchemy import (
     LargeBinary,
     Text,
     ForeignKey,
+    DateTime,
 )
+from datetime import datetime
 from sqlalchemy.orm import relationship
 
 from ..db import Base
@@ -15,6 +17,7 @@ from ..db import Base
 __all__ = [
     "User",
     "Document",
+    "DocumentRevision",
     "Project",
     "Reference",
     "Setting",
@@ -51,6 +54,7 @@ class Document(Base):
 
     owner = relationship("User", back_populates="documents")
     project = relationship("Project", back_populates="documents")
+    revisions = relationship("DocumentRevision", back_populates="document", cascade="all, delete-orphan")
 
 
 class Project(Base):
@@ -96,3 +100,16 @@ class Setting(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     user = relationship("User")
+
+
+class DocumentRevision(Base):
+    """Historical record of document text changes."""
+
+    __tablename__ = "document_revisions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    document_id = Column(Integer, ForeignKey("documents.id"))
+    text = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    document = relationship("Document", back_populates="revisions")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from datetime import datetime
 from pydantic import BaseModel
 
 class UserBase(BaseModel):
@@ -48,6 +49,16 @@ class DocumentRead(DocumentBase):
 
     class Config:
         orm_mode = True
+
+
+class DocumentRevisionRead(BaseModel):
+    id: int
+    document_id: int
+    text: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
 
 
 class ProjectBase(BaseModel):


### PR DESCRIPTION
## Summary
- add `DocumentRevision` model to record document changes
- store revisions when updating and allow rollback
- enforce history limit via `DOC_HISTORY_LIMIT`
- expose revision listing and restoration endpoints
- test saving revisions and restoring a previous version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ed3f27808322bb2e46c2218173f6