### PR TITLE
Add media management panels and patch sync

### DIFF
--- a/backend/api/references.py
+++ b/backend/api/references.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from sqlalchemy.orm import Session
+from typing import List
 
 from .. import schemas, models
 from ..services import references as ref_service
@@ -45,4 +46,17 @@ def read_reference(ref_id: int, token: str, db: Session = Depends(get_db)):
     if not ref:
         raise HTTPException(status_code=404, detail="Reference not found")
     return ref
+
+
+@router.get("/project/{project_id}", response_model=List[schemas.ReferenceRead])
+def list_references(project_id: int, token: str, db: Session = Depends(get_db)):
+    """List references for a project."""
+    user = get_current_user(token, db)
+    refs = (
+        db.query(models.Reference)
+        .join(models.Project)
+        .filter(models.Project.id == project_id, models.Project.author_id == user.id)
+        .all()
+    )
+    return refs
 

--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -10,6 +10,13 @@ function login() {
 }
 
 describe('App E2E', () => {
+  it('admin can login', () => {
+    cy.visit('/login')
+    cy.get('input[placeholder="Username"]').type('admin')
+    cy.get('input[type="password"]').type('admin')
+    cy.contains('button', 'Login').click()
+    cy.url().should('include', '/projects')
+  })
   it('registers a new user', () => {
     cy.visit('/register')
     cy.get('input[placeholder="Username"]').type(username)
@@ -49,6 +56,28 @@ describe('App E2E', () => {
         const docId = r.body.id
         cy.visit(`/project/${projectId}/documents/${docId}`)
         cy.contains('h1', 'Hello')
+        cy.get('textarea').type('\nMore text')
+        cy.get('textarea').blur()
+        cy.contains('More text')
+        cy.get('input[type="file"]').first().selectFile('cypress/fixtures/sample.pdf')
+      })
+    })
+  })
+
+  it('uploads reference pdf', () => {
+    login()
+    cy.window().then(win => {
+      const token = win.localStorage.getItem('token')
+      const projectId = win.sessionStorage.getItem('projectId')
+      cy.request({
+        method: 'POST',
+        url: 'http://localhost:8000/documents/',
+        qs: { token },
+        body: { text: 'refdoc', project_id: projectId }
+      }).then(r => {
+        const docId = r.body.id
+        cy.visit(`/project/${projectId}/documents/${docId}`)
+        cy.get('input[type="file"]').eq(2).selectFile('cypress/fixtures/sample.pdf')
       })
     })
   })

--- a/frontend/cypress/fixtures/sample.pdf
+++ b/frontend/cypress/fixtures/sample.pdf
@@ -1,0 +1,7 @@
+%PDF-1.4
+1 0 obj
+<<>>
+endobj
+trailer
+<<>>
+%%EOF

--- a/frontend/cypress/fixtures/sample.png
+++ b/frontend/cypress/fixtures/sample.png
@@ -1,0 +1,2 @@
+wzbzhUecS+L1RwlBdazmxz9hlDXy1OWG8RdNvRNGRedGsq76xX+Uq/8j/1lOzt3ntzQUN36i3Jhr
+wi1O6H1lhVRFYYtBQYzX1FY

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.11.0",
+        "diff-match-patch": "^1.0.5",
         "dompurify": "^3.2.6",
         "markdown-it": "^14.1.0",
         "react": "^19.1.0",
@@ -3457,6 +3458,12 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "diff-match-patch": "^1.0.5",
     "dompurify": "^3.2.6",
     "markdown-it": "^14.1.0",
     "react": "^19.1.0",

--- a/frontend/src/pages/DocumentEditor.tsx
+++ b/frontend/src/pages/DocumentEditor.tsx
@@ -4,6 +4,7 @@ import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import api from '../api'
 import { useAuth } from '../AuthContext'
+import usePatchSync from '../usePatchSync'
 
 const md = new MarkdownIt()
 
@@ -16,21 +17,90 @@ export default function DocumentEditor() {
   const { id, docId } = useParams()
   const { token } = useAuth()
   const [text, setText] = useState('')
+  const [refs, setRefs] = useState<any[]>([])
+  const sync = usePatchSync(docId, text)
+
+  useEffect(() => {
+    if (!token || !id) return
+    api.get(`/references/project/${id}`, { params: { token } }).then(r => setRefs(r.data))
+  }, [token, id])
 
   useEffect(() => {
     if (!token || !docId) return
     api.get(`/documents/${docId}`, { params: { token } }).then(r => setText(r.data.text || ''))
   }, [token, docId])
 
-  const save = () => {
-    if (!token || !docId) return
-    api.put(`/documents/${docId}`, { text }, { params: { token } })
+  const save = async () => {
+    await sync()
+  }
+
+  const uploadPdf = (file: File | null) => {
+    if (!file || !token || !docId) return
+    const fd = new FormData()
+    fd.append('pdf', file)
+    api.post(`/documents/${docId}/pdf`, fd, { params: { token } })
+  }
+
+  const uploadImage = (file: File | null) => {
+    if (!file || !token || !docId) return
+    const fd = new FormData()
+    fd.append('image', file)
+    api.post(`/documents/${docId}/image`, fd, { params: { token } })
+  }
+
+  const [query, setQuery] = useState('')
+  const [refPdf, setRefPdf] = useState<File | null>(null)
+
+  const addRef = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!token || !id) return
+    const fd = new FormData()
+    fd.append('project_id', id)
+    fd.append('query', query)
+    if (refPdf) fd.append('pdf', refPdf)
+    const r = await api.post('/references/', fd, { params: { token } })
+    setRefs([...refs, r.data])
+    setQuery('')
+    setRefPdf(null)
   }
 
   return (
     <div className="flex h-screen">
-      <textarea className="w-1/2 p-2 border" value={text} onChange={e => setText(e.target.value)} onBlur={save} />
-      <div className="w-1/2 p-2 prose prose-invert overflow-auto" dangerouslySetInnerHTML={{ __html: renderSanitizedMarkdown(text) }} />
+      <div className="w-2/3 flex flex-col">
+        <textarea
+          className="flex-1 p-2 border"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onBlur={save}
+        />
+        <div
+          className="flex-1 p-2 prose prose-invert overflow-auto"
+          dangerouslySetInnerHTML={{ __html: renderSanitizedMarkdown(text) }}
+        />
+      </div>
+      <div className="w-1/3 p-2 space-y-4 overflow-auto border-l">
+        <div>
+          <h2 className="font-bold mb-1">PDF</h2>
+          <input type="file" accept="application/pdf" onChange={e => uploadPdf(e.target.files?.[0] || null)} />
+        </div>
+        <div>
+          <h2 className="font-bold mb-1">Image</h2>
+          <input type="file" accept="image/*" onChange={e => uploadImage(e.target.files?.[0] || null)} />
+        </div>
+        <div>
+          <h2 className="font-bold mb-1">References</h2>
+          <form onSubmit={addRef} className="space-y-2">
+            <input className="border p-1 w-full" value={query} onChange={e => setQuery(e.target.value)} placeholder="PubMed ID" />
+            <input type="file" accept="application/pdf" onChange={e => setRefPdf(e.target.files?.[0] || null)} />
+            <button className="bg-blue-500 text-white px-2 py-1" type="submit">Add</button>
+          </form>
+          <ul className="mt-2 list-disc list-inside">
+            {refs.map(r => (
+              <li key={r.id}>{r.title}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/usePatchSync.ts
+++ b/frontend/src/usePatchSync.ts
@@ -1,0 +1,19 @@
+import { useRef } from 'react'
+import api from './api'
+import { useAuth } from './AuthContext'
+import DiffMatchPatch from 'diff-match-patch'
+
+export default function usePatchSync(docId?: string, text?: string) {
+  const { token } = useAuth()
+  const prev = useRef(text || '')
+  const dmp = useRef(new DiffMatchPatch())
+
+  return async () => {
+    if (!token || !docId) return
+    const patch = dmp.current.patch_toText(dmp.current.patch_make(prev.current, text || ''))
+    prev.current = text || ''
+    if (patch) {
+      await api.patch(`/documents/${docId}`, { patch }, { params: { token } })
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyPDF2
 httpx
 python-multipart
 python-dotenv
+diff-match-patch


### PR DESCRIPTION
## Summary
- enable diff-match-patch syncing and file upload endpoints
- add PDF/image/reference panels in the document editor
- support reference listing
- test frontend components and e2e flows with Cypress

## Testing
- `pytest -q`
- `npx vitest run --silent`
- `npm run test:e2e --silent` *(fails: Cypress binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888f03917848322b75a3562348ab247