### PR TITLE
Add chat themed panels

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,6 +39,27 @@ export default tseslint.config([
 ])
 ```
 
+## Styling
+
+This app uses Tailwind CSS with a small chat-inspired theme defined in
+`tailwind.config.cjs`. Custom colors are provided for the background, text and
+sidebar panels:
+
+```js
+extend: {
+  colors: {
+    'chat-bg': '#1f2937',   // dark background
+    'chat-text': '#f3f4f6', // light text
+    'chat-panel': '#374151' // panel background
+  }
+}
+```
+
+The global styles in `src/index.css` apply these colors to the body element.
+Components can use the classes `bg-chat-bg`, `text-chat-text` and
+`bg-chat-panel` to match the default theme. Panels in the editor are expandable
+using simple state toggles and Tailwind utility classes.
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-chat-bg text-chat-text font-sans;
+}

--- a/frontend/src/pages/DocumentEditor.tsx
+++ b/frontend/src/pages/DocumentEditor.tsx
@@ -51,6 +51,11 @@ export default function DocumentEditor() {
   const [query, setQuery] = useState('')
   const [refPdf, setRefPdf] = useState<File | null>(null)
 
+  const [showLit, setShowLit] = useState(true)
+  const [showPdfs, setShowPdfs] = useState(true)
+  const [showRefs, setShowRefs] = useState(true)
+  const [showMedia, setShowMedia] = useState(true)
+
   const addRef = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!token || !id) return
@@ -65,7 +70,7 @@ export default function DocumentEditor() {
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen bg-chat-bg text-chat-text">
       <div className="w-2/3 flex flex-col">
         <textarea
           className="flex-1 p-2 border"
@@ -80,25 +85,70 @@ export default function DocumentEditor() {
       </div>
       <div className="w-1/3 p-2 space-y-4 overflow-auto border-l">
         <div>
-          <h2 className="font-bold mb-1">PDF</h2>
-          <input type="file" accept="application/pdf" onChange={e => uploadPdf(e.target.files?.[0] || null)} />
+          <button
+            className="w-full flex justify-between items-center bg-chat-panel p-2 rounded"
+            onClick={() => setShowLit(!showLit)}
+          >
+            <span className="font-bold">Literature</span>
+            <span>{showLit ? '-' : '+'}</span>
+          </button>
+          {showLit && (
+            <div className="mt-2 text-sm">Add notes about the literature here.</div>
+          )}
         </div>
+
         <div>
-          <h2 className="font-bold mb-1">Image</h2>
-          <input type="file" accept="image/*" onChange={e => uploadImage(e.target.files?.[0] || null)} />
+          <button
+            className="w-full flex justify-between items-center bg-chat-panel p-2 rounded"
+            onClick={() => setShowPdfs(!showPdfs)}
+          >
+            <span className="font-bold">PDFs</span>
+            <span>{showPdfs ? '-' : '+'}</span>
+          </button>
+          {showPdfs && (
+            <div className="mt-2">
+              <input type="file" accept="application/pdf" onChange={e => uploadPdf(e.target.files?.[0] || null)} />
+            </div>
+          )}
         </div>
+
         <div>
-          <h2 className="font-bold mb-1">References</h2>
-          <form onSubmit={addRef} className="space-y-2">
-            <input className="border p-1 w-full" value={query} onChange={e => setQuery(e.target.value)} placeholder="PubMed ID" />
-            <input type="file" accept="application/pdf" onChange={e => setRefPdf(e.target.files?.[0] || null)} />
-            <button className="bg-blue-500 text-white px-2 py-1" type="submit">Add</button>
-          </form>
-          <ul className="mt-2 list-disc list-inside">
-            {refs.map(r => (
-              <li key={r.id}>{r.title}</li>
-            ))}
-          </ul>
+          <button
+            className="w-full flex justify-between items-center bg-chat-panel p-2 rounded"
+            onClick={() => setShowMedia(!showMedia)}
+          >
+            <span className="font-bold">Media</span>
+            <span>{showMedia ? '-' : '+'}</span>
+          </button>
+          {showMedia && (
+            <div className="mt-2">
+              <input type="file" accept="image/*" onChange={e => uploadImage(e.target.files?.[0] || null)} />
+            </div>
+          )}
+        </div>
+
+        <div>
+          <button
+            className="w-full flex justify-between items-center bg-chat-panel p-2 rounded"
+            onClick={() => setShowRefs(!showRefs)}
+          >
+            <span className="font-bold">References</span>
+            <span>{showRefs ? '-' : '+'}</span>
+          </button>
+          {showRefs && (
+            <div className="mt-2">
+              <form onSubmit={addRef} className="space-y-2">
+                <input className="border p-1 w-full" value={query} onChange={e => setQuery(e.target.value)} placeholder="PubMed ID" />
+                <input type="file" accept="application/pdf" onChange={e => setRefPdf(e.target.files?.[0] || null)} />
+                <button className="bg-blue-500 text-white px-2 py-1" type="submit">Add</button>
+              </form>
+              <ul className="mt-2 list-disc list-inside text-sm">
+                {refs.map(r => (
+                  <li key={r.id}>{r.title}</li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -4,7 +4,13 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'chat-bg': '#1f2937',
+        'chat-text': '#f3f4f6',
+        'chat-panel': '#374151',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add collapsible panels for literature, PDFs, references and media
- introduce dark chat-inspired Tailwind theme
- document theme options

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f390319c8322aa613b188481ab3d