### PR TITLE
Add reference listing and delete routes

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -84,6 +84,8 @@ class Reference(Base):
     journal = Column(String)
     year = Column(String)
     pdf = Column(LargeBinary)
+    filename = Column(String)
+    filetype = Column(String)
     project_id = Column(Integer, ForeignKey("projects.id"))
 
     project = relationship("Project", back_populates="references")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -95,6 +95,8 @@ class ReferenceRead(BaseModel):
     authors: str
     journal: str
     year: str
+    filename: Optional[str] = None
+    filetype: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/tests/test_pubmed_api.py
+++ b/tests/test_pubmed_api.py
@@ -122,4 +122,6 @@ def test_fetch_pubmed_reference_network_error():
         "authors": "",
         "journal": "",
         "year": "",
+        "filename": None,
+        "filetype": None,
     }

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,68 @@
+import uuid
+from unittest.mock import patch
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def get_token():
+    username = f"refu_{uuid.uuid4().hex[:6]}"
+    client.post("/auth/register", json={"username": username, "password": "secret"})
+    resp = client.post("/auth/login", json={"username": username, "password": "secret"})
+    return resp.json()["access_token"]
+
+
+def test_list_filter_and_delete_references():
+    token = get_token()
+    proj_resp = client.post(
+        "/projects/",
+        params={"token": token},
+        json={"label": "Refs", "description": "test"},
+    )
+    assert proj_resp.status_code == 200
+    proj_id = proj_resp.json()["id"]
+
+    def fake_fetch(q):
+        return {"title": q, "authors": "", "journal": "", "year": "2024"}
+
+    with patch("backend.api.references.ref_service.fetch_reference", side_effect=fake_fetch):
+        ref1 = client.post(
+            "/references/",
+            params={"token": token},
+            data={"project_id": proj_id, "query": "alpha"},
+        ).json()
+        ref2 = client.post(
+            "/references/",
+            params={"token": token},
+            data={"project_id": proj_id, "query": "beta"},
+        ).json()
+        ref3 = client.post(
+            "/references/",
+            params={"token": token},
+            data={"project_id": proj_id, "query": "gamma"},
+        ).json()
+
+    list_resp = client.get("/references/user", params={"token": token})
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 3
+
+    search_resp = client.get("/references/user", params={"token": token, "search": "beta"})
+    assert search_resp.status_code == 200
+    data = search_resp.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "beta"
+
+    sort_resp = client.get("/references/user", params={"token": token, "sort": "-title"})
+    assert sort_resp.status_code == 200
+    titles = [r["title"] for r in sort_resp.json()]
+    assert titles == sorted([ref1["title"], ref2["title"], ref3["title"]], reverse=True)
+
+    del_resp = client.delete(f"/references/{ref2['id']}", params={"token": token})
+    assert del_resp.status_code == 200
+
+    get_resp = client.get(f"/references/{ref2['id']}", params={"token": token})
+    assert get_resp.status_code == 404


### PR DESCRIPTION
## Summary
- extend reference model with filename/filetype metadata
- expose `/references/user` endpoint for listing references with search/sort
- allow deleting references with `DELETE /references/{ref_id}`
- capture filename/filetype on reference creation
- add tests for new behaviour and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a71de606c83229beb3443890ad8e8