### PR TITLE
Add reference store and integrate pages

### DIFF
--- a/frontend/src/stores/reference.js
+++ b/frontend/src/stores/reference.js
@@ -1,0 +1,66 @@
+import { defineStore } from 'pinia'
+import { useApiStore } from './api'
+import { useUserStore } from './user'
+
+export const useReferenceStore = defineStore('reference', {
+  state: () => ({
+    references: [],
+    loading: false,
+    error: null
+  }),
+
+  getters: {
+    referenceCount: (state) => state.references.length,
+    pdfCount: (state) => state.references.filter(r => r.filetype && r.filetype.includes('pdf')).length
+  },
+
+  actions: {
+    async fetchAll(projectId = null, params = {}) {
+      const userStore = useUserStore()
+      if (!userStore.token) return
+      const apiStore = useApiStore()
+      this.loading = true
+      try {
+        const query = new URLSearchParams({ token: userStore.token, ...params }).toString()
+        const endpoint = projectId ? `/references/project/${projectId}` : '/references/user'
+        const data = await apiStore.get(`${endpoint}?${query}`, userStore.token)
+        this.references = data
+        return data
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async upload({ projectId, query, file }) {
+      const userStore = useUserStore()
+      if (!userStore.token) return
+      const apiStore = useApiStore()
+      const form = new FormData()
+      form.append('project_id', projectId)
+      form.append('query', query)
+      if (file) form.append('pdf', file)
+
+      this.loading = true
+      try {
+        const data = await apiStore.post(`/references/?token=${userStore.token}`, form, userStore.token)
+        this.references.push(data)
+        return data
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async delete(id) {
+      const userStore = useUserStore()
+      if (!userStore.token) return
+      const apiStore = useApiStore()
+      this.loading = true
+      try {
+        await apiStore.delete(`/references/${id}?token=${userStore.token}`, userStore.token)
+        this.references = this.references.filter(r => r.id !== id)
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add a Pinia store for references with fetch, upload, and delete actions
- integrate the store in Library and Dashboard pages
- update state handling and counters using the new store

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a743cc7d4832296bb98793c351d15