### PR TITLE
Fix unused props variable

### DIFF
--- a/frontend/src/components/ui/FileUpload.vue
+++ b/frontend/src/components/ui/FileUpload.vue
@@ -22,7 +22,7 @@
 import { ref } from 'vue'
 import BaseModal from './BaseModal.vue'
 
-const props = defineProps({
+defineProps({
   show: { type: Boolean, default: false },
   accept: { type: String, default: '.pdf,.txt' },
   multiple: { type: Boolean, default: true }


### PR DESCRIPTION
## Summary
- clean up FileUpload component to avoid ESLint no-unused-vars error

## Testing
- `npm run lint`
- `./venv/bin/pip install pytest`
- `./venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a781f3e388322a44311e661265de6