### PR TITLE
Fix upload failures by respecting multipart forms

### DIFF
--- a/frontend/src/stores/api.js
+++ b/frontend/src/stores/api.js
@@ -20,9 +20,6 @@ export const useApiStore = defineStore('api', {
       const instance = axios.create({
         baseURL: API_BASE_URL,
         timeout: 10000,
-        headers: {
-          'Content-Type': 'application/json',
-        },
       })
 
       // Add request interceptor for authentication


### PR DESCRIPTION
## Summary
- remove the hard-coded `Content-Type: application/json` header in `api.js`
- all tests pass

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a79ca292083228e2778a88a2b08cc