### PR TITLE
Fix upload in library

### DIFF
--- a/frontend/src/pages/LibraryPage.vue
+++ b/frontend/src/pages/LibraryPage.vue
@@ -42,7 +42,8 @@ const sortKey = ref('title')
 const sortAsc = ref(true)
 
 async function fetchRefs() {
-  await referenceStore.fetchAll(1)
+  // fetch all references for the current user
+  await referenceStore.fetchAll()
 }
 
 onMounted(fetchRefs)
@@ -71,12 +72,13 @@ function remove(id) {
 }
 
 async function uploadFiles(files) {
-  for (const file of files) {
-    try {
-      await referenceStore.upload({ projectIds: [1], query: file.name, file })
-    } catch (err) {
-      console.error('upload fail', err)
+    for (const file of files) {
+      try {
+        // upload the reference without linking to a specific project
+        await referenceStore.upload({ query: file.name, file })
+      } catch (err) {
+        console.error('upload fail', err)
+      }
     }
-  }
 }
 </script>


### PR DESCRIPTION
## Summary
- fetch references without assuming a specific project
- upload references without linking to an unknown project

## Testing
- `./venv/bin/pytest -k references -q`

------
https://chatgpt.com/codex/tasks/task_e_688a863a1ef08322a85bad7f76fa8d72