### PR TITLE
Add media store and hook project file lists to API

### DIFF
--- a/frontend/src/stores/media.js
+++ b/frontend/src/stores/media.js
@@ -1,15 +1,73 @@
 import { defineStore } from 'pinia'
+import { useApiStore } from './api'
+import { useUserStore } from './user'
 
 export const useMediaStore = defineStore('media', {
   state: () => ({
+    media: [],
     loading: false,
     error: null
   }),
+
   actions: {
+    async fetch(projectId) {
+      const userStore = useUserStore()
+      if (!userStore.token || !projectId) return
+      const apiStore = useApiStore()
+      this.loading = true
+      try {
+        const data = await apiStore.get(`/documents/project/${projectId}?token=${userStore.token}`, userStore.token)
+        this.media = Array.isArray(data) ? data : []
+        return this.media
+      } finally {
+        this.loading = false
+      }
+    },
+
     async upload({ projectId = null, files = [] }) {
-      // Placeholder implementation until backend media endpoints are available
-      console.warn('Media upload not implemented yet', { projectId, files })
-      return { success: false, error: 'Not implemented' }
+      const userStore = useUserStore()
+      if (!userStore.token || !projectId || !files.length) return
+      const apiStore = useApiStore()
+      this.loading = true
+      this.error = null
+      try {
+        const uploaded = []
+        for (const file of files) {
+          const form = new FormData()
+          form.append('project_id', projectId)
+          form.append('label', file.name)
+          if (file.type.includes('pdf')) {
+            form.append('pdf', file)
+          } else {
+            form.append('image', file)
+          }
+          const doc = await apiStore.post(`/documents/?token=${userStore.token}`, form, userStore.token)
+          uploaded.push(doc)
+        }
+        await this.fetch(projectId)
+        return { success: true, data: uploaded }
+      } catch (err) {
+        this.error = err.response?.data?.detail || err.message || 'Upload failed'
+        return { success: false, error: this.error }
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async remove(id, projectId = null) {
+      const userStore = useUserStore()
+      if (!userStore.token) return
+      const apiStore = useApiStore()
+      this.loading = true
+      try {
+        await apiStore.delete(`/documents/${id}?token=${userStore.token}`, userStore.token)
+        this.media = this.media.filter(m => m.id !== id)
+        if (projectId) {
+          await this.fetch(projectId)
+        }
+      } finally {
+        this.loading = false
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- add Pinia store for project media with fetch/upload/remove actions
- load project references and media files from stores
- display file name, type and size with click-to-open or preview

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bb8b91d6c8322be6f5c3e578e9fd8