### PR TITLE
feat: add reference search dialog

### DIFF
--- a/frontend/src/components/project/ReferenceSearchDialog.vue
+++ b/frontend/src/components/project/ReferenceSearchDialog.vue
@@ -1,0 +1,99 @@
+<template>
+  <BaseModal
+    :show="props.show"
+    @close="emit('close')"
+    title="Add Reference"
+    size="lg"
+  >
+    <div class="space-y-4">
+      <div class="flex space-x-2">
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search references..."
+          class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+          @keyup.enter="performSearch"
+        />
+        <BaseButton @click="performSearch" :loading="searching">Search</BaseButton>
+      </div>
+
+      <div v-if="searchResults.length" class="max-h-64 overflow-y-auto border rounded">
+        <ul>
+          <li
+            v-for="ref in searchResults"
+            :key="ref.id"
+            class="flex items-center justify-between p-2 border-b last:border-b-0"
+          >
+            <div class="pr-2">
+              <div class="text-sm font-medium text-gray-800 truncate">
+                {{ ref.title || ref.filename }}
+              </div>
+              <div class="text-xs text-gray-500">
+                {{ ref.authors }}
+                <span v-if="ref.year">• {{ ref.year }}</span>
+              </div>
+            </div>
+            <BaseButton
+              size="sm"
+              variant="outline"
+              @click="selectReference(ref)"
+            >
+              Add
+            </BaseButton>
+          </li>
+        </ul>
+      </div>
+
+      <div v-else-if="hasSearched" class="text-sm text-gray-500">
+        No references found.
+      </div>
+    </div>
+  </BaseModal>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import BaseModal from '../ui/BaseModal.vue'
+import BaseButton from '../ui/BaseButton.vue'
+import { useReferenceStore } from '../../stores/reference'
+import { useApiStore } from '../../stores/api'
+import { useUserStore } from '../../stores/user'
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+  projectId: { type: Number, required: true }
+})
+
+const emit = defineEmits(['close', 'added'])
+
+const referenceStore = useReferenceStore()
+const apiStore = useApiStore()
+const userStore = useUserStore()
+
+const searchQuery = ref('')
+const searchResults = ref([])
+const hasSearched = ref(false)
+const searching = ref(false)
+
+async function performSearch() {
+  if (!searchQuery.value.trim()) return
+  searching.value = true
+  const prev = [...referenceStore.references]
+  try {
+    const results = await referenceStore.fetchAll(null, { search: searchQuery.value.trim() })
+    searchResults.value = results || []
+  } finally {
+    referenceStore.references = prev
+    searching.value = false
+    hasSearched.value = true
+  }
+}
+
+async function selectReference(ref) {
+  if (!ref?.id) return
+  await apiStore.post(`/references/${ref.id}/projects/${props.projectId}?token=${userStore.token}`)
+  emit('added', ref)
+  emit('close')
+}
+</script>
+

--- a/frontend/src/pages/ProjectPage.vue
+++ b/frontend/src/pages/ProjectPage.vue
@@ -79,7 +79,7 @@
             <q-list dense class="q-pa-none">
               <!-- References section -->
               <q-expansion-item
-                v-model="referencesExpanded" 
+                v-model="referencesExpanded"
                 dense
                 expand-separator
                 class="text-grey-7"
@@ -88,6 +88,15 @@
                 <template v-slot:header>
                   <q-item-section class="text-caption text-weight-medium text-uppercase" style="letter-spacing: 0.05em;">
                     References ({{ references.length }})
+                  </q-item-section>
+                  <q-item-section side>
+                    <BaseButton
+                      size="sm"
+                      variant="outline"
+                      @click.stop="showReferenceSearch = true"
+                    >
+                      Add Reference
+                    </BaseButton>
                   </q-item-section>
                 </template>
                 
@@ -485,6 +494,13 @@
       :show="showPubMedSearch"
       @close="showPubMedSearch = false"
     />
+
+    <ReferenceSearchDialog
+      :show="showReferenceSearch"
+      :project-id="projectId"
+      @close="showReferenceSearch = false"
+      @added="handleReferenceAdded"
+    />
 </template>
 
 <script setup>
@@ -495,6 +511,7 @@ import PageHeader from '../components/ui/PageHeader.vue'
 import FileActionDialog from '../components/project/FileActionDialog.vue'
 import FileUpload from '../components/ui/FileUpload.vue'
 import PubMedSearch from '../components/ui/PubMedSearch.vue'
+import ReferenceSearchDialog from '../components/project/ReferenceSearchDialog.vue'
 import { useReferenceStore } from '../stores/reference'
 import { useMediaStore } from '../stores/media'
 import { useUserStore } from '../stores/user'
@@ -510,6 +527,7 @@ const showFileAction = ref(false)
 const showPdfUpload = ref(false)
 const showMediaUpload = ref(false)
 const showPubMedSearch = ref(false)
+const showReferenceSearch = ref(false)
 const droppedFiles = ref([])
 
 const projectId = computed(() => route.params.id)
@@ -667,6 +685,12 @@ onMounted(async () => {
     await mediaStore.fetch(projectId.value)
   }
 })
+
+async function handleReferenceAdded() {
+  if (projectId.value) {
+    await referenceStore.fetchAll(projectId.value)
+  }
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- allow searching for existing references and selecting them via new ReferenceSearchDialog
- add “Add Reference” button on project page and open search dialog
- link selected references to the current project and refresh list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bbced3c6883229683be16a86a3a17