### PR TITLE
feat: add media store and editing

### DIFF
--- a/frontend/src/components/ui/MediaEditDialog.vue
+++ b/frontend/src/components/ui/MediaEditDialog.vue
@@ -1,0 +1,98 @@
+<template>
+  <div v-if="show" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" @click="handleBackdropClick">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-4" @click.stop>
+      <div class="flex items-center justify-between p-6 border-b border-gray-200">
+        <h3 class="text-lg font-medium text-gray-900">Edit Media</h3>
+        <button @click="handleClose" class="text-gray-400 hover:text-gray-600 transition-colors">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="p-6 space-y-4 max-h-[60vh] overflow-auto">
+        <div v-if="error" class="p-3 bg-red-50 border border-red-200 text-red-800 rounded">
+          {{ error }}
+        </div>
+        <div>
+          <label for="label" class="block text-sm font-medium text-gray-700 mb-1">Label</label>
+          <input
+            id="label"
+            v-model="formData.label"
+            type="text"
+            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+        <div>
+          <label for="description" class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <textarea
+            id="description"
+            v-model="formData.description"
+            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-vertical"
+          ></textarea>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-end p-6 border-t border-gray-200 space-x-3">
+        <BaseButton variant="outline" @click="handleClose">Cancel</BaseButton>
+        <BaseButton variant="primary" :loading="loading" @click="handleSubmit">Save Changes</BaseButton>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useMediaStore } from '../../stores/media'
+import BaseButton from './BaseButton.vue'
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+  media: { type: Object, default: null }
+})
+
+const emit = defineEmits(['close', 'updated'])
+
+const mediaStore = useMediaStore()
+const loading = ref(false)
+const error = ref('')
+const formData = ref({ label: '', description: '' })
+
+watch(() => props.media, (m) => {
+  if (m) {
+    formData.value = {
+      label: m.label || '',
+      description: m.description || ''
+    }
+  }
+}, { immediate: true })
+
+function handleClose() {
+  error.value = ''
+  emit('close')
+}
+
+function handleBackdropClick() {
+  emit('close')
+}
+
+async function handleSubmit() {
+  if (!props.media) return
+  loading.value = true
+  error.value = ''
+  const { success, data, error: err } = await mediaStore.update(props.media.id, formData.value)
+  if (success) {
+    emit('updated', data)
+    handleClose()
+  } else {
+    error.value = err || 'Failed to update media'
+  }
+  loading.value = false
+}
+</script>
+
+<style scoped>
+.resize-vertical {
+  resize: vertical;
+}
+</style>

--- a/frontend/src/stores/media.js
+++ b/frontend/src/stores/media.js
@@ -15,37 +15,38 @@ export const useMediaStore = defineStore('media', {
       if (!userStore.token || !projectId) return
       const apiStore = useApiStore()
       this.loading = true
+      this.error = null
       try {
         const data = await apiStore.get(`/documents/project/${projectId}?token=${userStore.token}`, userStore.token)
         this.media = Array.isArray(data) ? data : []
         return this.media
+      } catch (err) {
+        this.error = err.response?.data?.detail || err.message || 'Failed to load media'
+        return []
       } finally {
         this.loading = false
       }
     },
 
-    async upload({ projectId = null, files = [] }) {
+    async upload({ projectId, file, label = '', description = '' }) {
       const userStore = useUserStore()
-      if (!userStore.token || !projectId || !files.length) return
+      if (!userStore.token || !projectId || !file) return { success: false, error: 'Missing data' }
       const apiStore = useApiStore()
+      const form = new FormData()
+      form.append('project_id', projectId)
+      if (label) form.append('label', label)
+      if (description) form.append('description', description)
+      if (file.type.includes('pdf')) {
+        form.append('pdf', file)
+      } else {
+        form.append('image', file)
+      }
       this.loading = true
       this.error = null
       try {
-        const uploaded = []
-        for (const file of files) {
-          const form = new FormData()
-          form.append('project_id', projectId)
-          form.append('label', file.name)
-          if (file.type.includes('pdf')) {
-            form.append('pdf', file)
-          } else {
-            form.append('image', file)
-          }
-          const doc = await apiStore.post(`/documents/?token=${userStore.token}`, form, userStore.token)
-          uploaded.push(doc)
-        }
-        await this.fetch(projectId)
-        return { success: true, data: uploaded }
+        const data = await apiStore.post(`/documents/?token=${userStore.token}`, form, userStore.token)
+        this.media.push(data)
+        return { success: true, data }
       } catch (err) {
         this.error = err.response?.data?.detail || err.message || 'Upload failed'
         return { success: false, error: this.error }
@@ -54,17 +55,38 @@ export const useMediaStore = defineStore('media', {
       }
     },
 
-    async remove(id, projectId = null) {
+    async update(id, { label = null, description = null }) {
       const userStore = useUserStore()
-      if (!userStore.token) return
+      if (!userStore.token || !id) return { success: false, error: 'Missing data' }
       const apiStore = useApiStore()
       this.loading = true
+      this.error = null
+      try {
+        const data = await apiStore.put(`/documents/${id}?token=${userStore.token}`, { label, description }, userStore.token)
+        const index = this.media.findIndex(m => m.id === id)
+        if (index >= 0) {
+          this.media[index] = data
+        }
+        return { success: true, data }
+      } catch (err) {
+        this.error = err.response?.data?.detail || err.message || 'Update failed'
+        return { success: false, error: this.error }
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async delete(id) {
+      const userStore = useUserStore()
+      if (!userStore.token || !id) return
+      const apiStore = useApiStore()
+      this.loading = true
+      this.error = null
       try {
         await apiStore.delete(`/documents/${id}?token=${userStore.token}`, userStore.token)
         this.media = this.media.filter(m => m.id !== id)
-        if (projectId) {
-          await this.fetch(projectId)
-        }
+      } catch (err) {
+        this.error = err.response?.data?.detail || err.message || 'Delete failed'
       } finally {
         this.loading = false
       }


### PR DESCRIPTION
## Summary
- add Pinia media store for project documents
- allow editing media label/description via MediaEditDialog
- wire media store into ProjectPage for uploads and editing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bc00ae5fc83229c82c1aac08815cf